### PR TITLE
docs(readme.md): 코드블럭 언어 지정, 오타 수정, yarn 추가, 포맷팅, import 예시 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,16 @@
 > 하위 버전에서는 테스트하지 않았습니다.
 
 ## 설치
-```
+```bash
 $ npm install vue-daum-map --save
+# 혹은
+$ yarn add vue-daum-map
 ```
 
 ## 컴포넌트 사용 예제
 
 ### 템플릿 예제
-```
+```vue
 <vue-daum-map
       :appKey="appKey"
       :center.sync="center"
@@ -49,29 +51,35 @@ $ npm install vue-daum-map --save
       @idle=""
       @tilesloaded=""
       @maptypeid_changed=""
-      style="width:500px;height:400px;">
-    </vue-daum-map>
+      style="width:500px;height:400px;"/>
+```
+
+```js
+import VueDaumMap from 'vue-daum-map'
 ```
 
 ### 속성 예제
-```
-data: () => ({
-    appKey: 'd650a15bea81e28dadb716657ad03d75' // 테스트용 appkey
-    center: {lat:33.450701, lng:126.570667}, // 지도의 중심 좌표
-    level: 3 // 지도의 레벨(확대, 축소 정도),
-    mapTypeId: VueDaumMap.MapTypeId.NORMAL, // 맵 타입
-    libraries: [], // 추가로 불러올 라이브러리
-    map: null // 지도 객체. 지도가 로드되면 할당됨.
-}),
-
+```js
+{
+    data: () => ({
+        appKey: 'd650a15bea81e28dadb716657ad03d75', // 테스트용 appkey
+        center: {lat:33.450701, lng:126.570667}, // 지도의 중심 좌표
+        level: 3, // 지도의 레벨(확대, 축소 정도),
+        mapTypeId: VueDaumMap.MapTypeId.NORMAL, // 맵 타입
+        libraries: [], // 추가로 불러올 라이브러리
+        map: null // 지도 객체. 지도가 로드되면 할당됨.
+    }),
+}
 ```
 
 ### 메서드 예제
-```
-methods: {
-    // 지도가 로드 완료되면 load 이벤트 발생
-    onLoad (map) {
-        this.map = map
+```js
+{
+    methods: {
+        // 지도가 로드 완료되면 load 이벤트 발생
+        onLoad (map) {
+            this.map = map
+        }
     }
 }
 ```


### PR DESCRIPTION
안녕하세요? 

편리한 컴포넌트 감사드립니다. 

README.md 를 더 보기 쉽고 사용자 친화적으로(e.g. 복사 및 붙여넣기가 쉽도록) 개선할 수 있을듯 하여 PR 드립니다 :)

변경사항은 diff 로도 보시되, 실제 렌더링 된 내용도 따로 찾지 않고 한번의 클릭으로 보시기 쉽도록 여기 [링크](https://github.com/jjangga0214/vue-daum-map/tree/patch/docs/template)걸어 드립니다.

## 코드블럭 언어 지정

- vue(템플릿예제)
- js(템플릿 예제, 속성 예제, 메서드 예제)
- bash(설치)

## 오타 수정

속성 예제에 각 필드 뒤에 빠졌던 콤마(,) 추가

## yarn 추가

설치 커맨드에 yarn 도 추가

## 포맷팅

js snippet 포맷팅

## import 예시 추가

`import VueDaumMap from 'vue-daum-map'` 예시 추가